### PR TITLE
Add retrieval method for stream subset by date

### DIFF
--- a/src/NEventStore.Persistence.AcceptanceTests/ExtensionMethods.cs
+++ b/src/NEventStore.Persistence.AcceptanceTests/ExtensionMethods.cs
@@ -69,6 +69,25 @@ namespace NEventStore.Persistence.AcceptanceTests
                 messages);
         }
 
+        public static CommitAttempt BuildAttemptFromPrevious(this string streamId, ICommit previous, DateTime? now = null)
+        {
+            now = now ?? SystemTime.UtcNow;
+
+            var messages = new List<EventMessage>
+            {
+                new EventMessage {Body = new SomeDomainEvent {SomeProperty = "Test"}},
+                new EventMessage {Body = new SomeDomainEvent {SomeProperty = "Test2"}},
+            };
+
+            return new CommitAttempt(previous.BucketId, streamId,
+                2,
+                Guid.NewGuid(),
+                previous.CommitSequence+1,
+                now.Value,
+                new Dictionary<string, object> { { "A header", "A string value" }, { "Another header", 2 } },
+                messages);
+        }
+
         public static CommitAttempt BuildNextAttempt(this ICommit commit)
         {
             var messages = new List<EventMessage>

--- a/src/NEventStore/Diagnostics/PerformanceCounterPersistenceEngine.cs
+++ b/src/NEventStore/Diagnostics/PerformanceCounterPersistenceEngine.cs
@@ -73,6 +73,11 @@ namespace NEventStore.Diagnostics
             throw new NotImplementedException();
         }
 
+        public IEnumerable<ICommit> GetStreamCommitsFrom(string bucketId, DateTime start, params string[] streamIds)
+        {
+            return _persistence.GetStreamCommitsFrom(bucketId, start, streamIds);
+        }
+
         public IEnumerable<ICommit> GetAggregatesStreams(string bucketId, string streamIdOriginal)
         {
             throw new NotImplementedException();

--- a/src/NEventStore/Persistence/IPersistStreams.cs
+++ b/src/NEventStore/Persistence/IPersistStreams.cs
@@ -36,7 +36,18 @@ namespace NEventStore.Persistence
         IEnumerable<ICommit> GetFrom(string bucketId, DateTime start);
 
         IEnumerable<ICommit> GetStreams(string bucketId, params string[] streamIds);
-        
+
+        /// <summary>
+        ///     Gets all commits for the supplied steams that occured on or after the specified starting time.
+        /// </summary>
+        /// <param name="bucketId">The value which uniquely identifies bucket the stream belongs to.</param>
+        /// <param name="start">The point in time at which to start.</param>
+        /// <param name="streamIds">The streams to inspect.</param>
+        /// <returns>All commits that have occurred on or after the specified starting time.</returns>
+        /// <exception cref="StorageException" />
+        /// <exception cref="StorageUnavailableException" />
+        IEnumerable<ICommit> GetStreamCommitsFrom(string bucketId, DateTime start, params string[] streamIds);
+
         /// <summary>
         ///     Gets all commits after from the specified checkpoint. Use null to get from the beginning.
         /// </summary>

--- a/src/NEventStore/Persistence/InMemory/InMemoryPersistenceEngine.cs
+++ b/src/NEventStore/Persistence/InMemory/InMemoryPersistenceEngine.cs
@@ -51,6 +51,13 @@ namespace NEventStore.Persistence.InMemory
             throw new NotImplementedException();
         }
 
+        public IEnumerable<ICommit> GetStreamCommitsFrom(string bucketId, DateTime start, params string[] streamIds)
+        {
+            ThrowWhenDisposed();
+            Logger.Debug(Resources.GettingStreamCommitsFrom, streamIds.Count(), start);
+            return this[bucketId].GetStreamCommitsFrom(start, streamIds);
+        }
+
         public IEnumerable<ICommit> GetAggregatesStreams(string bucketId, string streamIdOriginal)
         {
             throw new NotImplementedException();
@@ -457,6 +464,13 @@ namespace NEventStore.Persistence.InMemory
                         .Where(x => x.HeadRevision >= x.SnapshotRevision + maxThreshold)
                         .Select(stream => new StreamHead(stream.BucketId, stream.StreamId, stream.HeadRevision, stream.SnapshotRevision));
                 }
+            }
+
+            public IEnumerable<ICommit> GetStreamCommitsFrom(DateTime start, string[] streamIds)
+            {
+                return _commits
+                    .Where(c => streamIds.Contains(c.StreamId) && c.CommitStamp >= start)
+                    .OrderBy(c => c.CommitSequence);
             }
 
             public ISnapshot GetSnapshot(string streamId, int maxRevision)

--- a/src/NEventStore/Persistence/PipelineHooksAwarePersistanceDecorator.cs
+++ b/src/NEventStore/Persistence/PipelineHooksAwarePersistanceDecorator.cs
@@ -72,6 +72,11 @@ namespace NEventStore.Persistence
             return ExecuteHooks(_original.GetStreams(bucketId, streamIds));
         }
 
+        public IEnumerable<ICommit> GetStreamCommitsFrom(string bucketId, DateTime start, params string[] streamIds)
+        {
+            return ExecuteHooks(_original.GetStreamCommitsFrom(bucketId, start, streamIds));
+        }
+
         public IEnumerable<ICommit> GetAggregatesStreams(string bucketId, string streamIdOriginal)
         {
             throw new NotImplementedException();

--- a/src/NEventStore/Persistence/Sql/ISqlDialect.cs
+++ b/src/NEventStore/Persistence/Sql/ISqlDialect.cs
@@ -20,6 +20,7 @@ namespace NEventStore.Persistence.Sql
         string GetCommitsFromToInstant { get; }
 
         string GetStreams { get; }
+        string GetStreamCommitsFromInstant { get; }
 
         string PersistCommit { get; }
         string DuplicateCommit { get; }

--- a/src/NEventStore/Persistence/Sql/Messages.Designer.cs
+++ b/src/NEventStore/Persistence/Sql/Messages.Designer.cs
@@ -70,15 +70,6 @@ namespace NEventStore.Persistence.Sql {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adding parameter named &apos;{0}&apos; to statement..
-        /// </summary>
-        internal static string GettingAggregatesStreams {
-            get {
-                return ResourceManager.GetString("GettingAggregatesStreams", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Adding snapshot to stream &apos;{0}&apos; at position {1}..
         /// </summary>
         internal static string AddingSnapshot {
@@ -367,6 +358,15 @@ namespace NEventStore.Persistence.Sql {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Getting streams for aggregate id: &apos;{0}&apos;..
+        /// </summary>
+        internal static string GettingAggregatesStreams {
+            get {
+                return ResourceManager.GetString("GettingAggregatesStreams", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Getting all commits for stream &apos;{0}&apos; between revisions &apos;{1}&apos; and &apos;{2}&apos;..
         /// </summary>
         internal static string GettingAllCommitsBetween {
@@ -408,6 +408,15 @@ namespace NEventStore.Persistence.Sql {
         internal static string GettingRevision {
             get {
                 return ResourceManager.GetString("GettingRevision", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Getting commits for {0} streams since {1}.
+        /// </summary>
+        internal static string GettingStreamsFrom {
+            get {
+                return ResourceManager.GetString("GettingStreamsFrom", resourceCulture);
             }
         }
         

--- a/src/NEventStore/Persistence/Sql/Messages.resx
+++ b/src/NEventStore/Persistence/Sql/Messages.resx
@@ -300,4 +300,7 @@
   <data name="DeletingStreams" xml:space="preserve">
     <value>Deleting streams '{0}' from bucket '{1}'.</value>
   </data>
+  <data name="GettingStreamsFrom" xml:space="preserve">
+    <value>Getting commits for {0} streams since {1}</value>
+  </data>
 </root>

--- a/src/NEventStore/Persistence/Sql/SqlDialects/CommonSqlDialect.cs
+++ b/src/NEventStore/Persistence/Sql/SqlDialects/CommonSqlDialect.cs
@@ -59,6 +59,11 @@ namespace NEventStore.Persistence.Sql.SqlDialects
             get { return CommonSqlStatements.GetMultipleStreams; }
         }
 
+        public string GetStreamCommitsFromInstant
+        {
+            get { return CommonSqlStatements.GetMultipleStreamCommitsFromInstant; }
+        }
+
         public abstract string PersistCommit { get; }
 
         public virtual string DuplicateCommit

--- a/src/NEventStore/Persistence/Sql/SqlDialects/CommonSqlStatements.Designer.cs
+++ b/src/NEventStore/Persistence/Sql/SqlDialects/CommonSqlStatements.Designer.cs
@@ -103,18 +103,8 @@ namespace NEventStore.Persistence.Sql.SqlDialects {
             get {
                 return ResourceManager.GetString("DeleteStreams", resourceCulture);
             }
-        }        
-                
-        /// <summary>
-        ///   Looks up a localized string similar to DELETE FROM Commits WHERE BucketId = @BucketId AND StreamId = @StreamId 
-        /// AND (SELECT SUM(Items) FROM Commits WHERE BucketId = @BucketId AND StreamId = @StreamId) = @ItemCount;.
-        /// </summary>
-        internal static string SafeDeleteStream {
-            get {
-                return ResourceManager.GetString("SafeDeleteStream", resourceCulture);
-            }
-        }     
-                
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to DROP TABLE Snapshots;
         ///DROP TABLE Commits;.
@@ -203,6 +193,23 @@ namespace NEventStore.Persistence.Sql.SqlDialects {
         /// WHERE BucketId = &apos;{0}&apos;
         ///   AND StreamId IN  {1}
         ///   AND StreamRevision &gt;= 0
+        ///   AND (StreamRevision - Items) &lt; @StreamRevision
+        ///   AND CommitSequence &gt; @CommitSequence
+        ///   AND CommitStamp &gt;= @CommitStamp
+        /// ORDER BY CommitSequence.
+        /// </summary>
+        internal static string GetMultipleStreamCommitsFromInstant {
+            get {
+                return ResourceManager.GetString("GetMultipleStreamCommitsFromInstant", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SELECT BucketId, StreamId, StreamIdOriginal, StreamRevision, CommitId, CommitSequence, CommitStamp,  CheckpointNumber, Headers, Payload
+        ///  FROM Commits
+        /// WHERE BucketId = &apos;{0}&apos;
+        ///   AND StreamId IN  {1}
+        ///   AND StreamRevision &gt;= 0
         ///   AND(StreamRevision - Items) &lt; @StreamRevision
         ///   AND CommitSequence &gt; 0
         /// ORDER BY CommitSequence
@@ -213,7 +220,7 @@ namespace NEventStore.Persistence.Sql.SqlDialects {
                 return ResourceManager.GetString("GetMultipleStreams", resourceCulture);
             }
         }
-                
+        
         /// <summary>
         ///   Looks up a localized string similar to SELECT *
         ///  FROM Snapshots
@@ -290,6 +297,22 @@ namespace NEventStore.Persistence.Sql.SqlDialects {
         internal static string PurgeStorage {
             get {
                 return ResourceManager.GetString("PurgeStorage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DELETE FROM Commits
+        ///            WHERE BucketId = @BucketId AND 
+        ///            StreamId = @StreamId AND
+        ///            (SELECT SUM(Items) 
+        ///            FROM Commits
+        ///            WHERE BucketId = @BucketId AND 
+        ///            StreamId = @StreamId) = @Items;
+        ///    .
+        /// </summary>
+        internal static string SafeDeleteStream {
+            get {
+                return ResourceManager.GetString("SafeDeleteStream", resourceCulture);
             }
         }
     }

--- a/src/NEventStore/Persistence/Sql/SqlDialects/CommonSqlStatements.resx
+++ b/src/NEventStore/Persistence/Sql/SqlDialects/CommonSqlStatements.resx
@@ -254,4 +254,15 @@ DELETE FROM Commits WHERE BucketId = @BucketId AND StreamId = @StreamId;</value>
     <value>DELETE FROM Snapshots WHERE BucketId =@BucketId AND StreamId IN {0};
 DELETE FROM Commits WHERE BucketId =@BucketId AND StreamId IN {0};</value>
   </data>
+  <data name="GetMultipleStreamCommitsFromInstant" xml:space="preserve">
+    <value>SELECT BucketId, StreamId, StreamIdOriginal, StreamRevision, CommitId, CommitSequence, CommitStamp,  CheckpointNumber, Headers, Payload
+  FROM Commits
+ WHERE BucketId = '{0}'
+   AND StreamId IN  {1}
+   AND StreamRevision &gt;= 0
+   AND (StreamRevision - Items) &lt; @StreamRevision
+   AND CommitSequence &gt; @CommitSequence
+   AND CommitStamp &gt;= @CommitStamp
+ ORDER BY CommitSequence</value>
+  </data>
 </root>

--- a/src/NEventStore/Resources.Designer.cs
+++ b/src/NEventStore/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NEventStore {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -237,6 +237,15 @@ namespace NEventStore {
         internal static string GettingSnapshotForStream {
             get {
                 return ResourceManager.GetString("GettingSnapshotForStream", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Getting commits for {0} streams since {1}.
+        /// </summary>
+        internal static string GettingStreamCommitsFrom {
+            get {
+                return ResourceManager.GetString("GettingStreamCommitsFrom", resourceCulture);
             }
         }
         

--- a/src/NEventStore/Resources.resx
+++ b/src/NEventStore/Resources.resx
@@ -288,4 +288,7 @@
   <data name="DeletingStream" xml:space="preserve">
     <value>Deleting stream '{0}' from bucket '{1}'.</value>
   </data>
+  <data name="GettingStreamCommitsFrom" xml:space="preserve">
+    <value>Getting commits for {0} streams since {1}</value>
+  </data>
 </root>


### PR DESCRIPTION
Add method to retrieve commits from a subset of streams that occur after a specified point in time.
Partner method for GetStreams - GetStreamCommitsFrom.
Note:  I've added passing unit tests for the new method - however, unit tests that were previously failing (or in an indeterminable state) before this work are still in this state following this commit.